### PR TITLE
Add support for looking up optional pegdown dependency #11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>org.scalatest</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>ScalaTest Maven Plugin</name>
   <description>Integrates ScalaTest into Maven</description>
 


### PR DESCRIPTION
When using a recent version of scalatest the pegdown dependency
is required for htmlreports.  To use htmlreports add the pegdown
dependency to the plugin definition in your project.

  <plugin>
    <groupId>org.scalatest</groupId>
    <artifactId>scalatest-maven-plugin</artifactId>
    <dependencies>
      <dependency>
        <groupId>org.pegdown</groupId>
        <artifactId>pegdown</artifactId>
        <version>1.4.2</version>
      </dependency>
    </dependencies>
  </plugin>
