### PR TITLE
Use correct flag (-P) for parallel=true

### DIFF
--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -434,7 +434,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
     }
 
     private List<String> parallel() {
-        return parallel ? singletonList("-c") : Collections.<String>emptyList();
+        return parallel ? singletonList("-P") : Collections.<String>emptyList();
     }
 
     //

--- a/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
@@ -103,8 +103,8 @@ class PluginTest extends JUnit3Suite with ShouldMatchers with PluginMatchers wit
   }
 
   def testConcurrent {
-    configure(_.parallel = true) should contain("-c")
-    configure(_.parallel = false) should not contain ("-c")
+    configure(_.parallel = true) should contain("-P")
+    configure(_.parallel = false) should not contain ("-P")
   }
 
   def testSuites {


### PR DESCRIPTION
Scalatest 2.0 uses `-P` instead of `-c` flag to enable parallel execution.
