### PR TITLE
Fixed two warnings caused by a line of out-of-date Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,13 @@
   <groupId>org.scalatest</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <name>ScalaTest Maven Plugin</name>
   <description>Integrates ScalaTest into Maven</description>
 
   <properties>
     <scala.major.version>2.11</scala.major.version>
-    <scala.minor.version>7</scala.minor.version>
+    <scala.minor.version>8</scala.minor.version>
     <scala.version>${scala.major.version}.${scala.minor.version}</scala.version>
     <scalatest.version>3.0.1</scalatest.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -230,7 +230,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
     /**
      * Span scale factor.
      *
-     * @parameter expression="${spanScaleFactor}"
+     * @parameter property="spanScaleFactor"
      */
     double spanScaleFactor = 1.0;
 


### PR DESCRIPTION
And one caused by a version mismatch.

Removed the -SNAPSHOT -- I think after this we're ready to release.