### PR TITLE
Add Travis-CI yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ cache:
   directories:
     - $HOME/.m2
 
+# skip mvn install
+install: true
+
 script: mvn clean package invoker:install invoker:run

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ cache:
   directories:
     - $HOME/.m2
 
-script: mvn verify
+script: mvn clean package invoker:install invoker:run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
+
 sudo: false
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+sudo: false
+jdk:
+  - oraclejdk8
+
+cache:
+  directories:
+    - $HOME/.m2
+
+script: mvn verify


### PR DESCRIPTION
This PR adds a `.travis.yml` file to run the maven integration tests in a Travis CI build.  You can then easily enable the Travis-CI integration for this repo and have Travis-CI run builds for every PR and commit on master.

An example of a passing build is [here](https://travis-ci.org/cstroe/scalatest-maven-plugin/builds/235508351).

Fixes #19