### PR TITLE
Use same JVM that maven is using.

### DIFF
--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -319,19 +319,6 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
         }
     }
 
-    private String getJvm()
-    {
-        // use the same JVM as the one used to run Maven (the "java.home" one)
-        String jvmToUse = System.getProperty( "java.home" ) + File.separator + "bin" + File.separator + "java";
-
-        if (isEmpty(jvmToUse)) {
-            jvmToUse = "java";
-        }
-
-        getLog().debug( "Using JVM: " + jvmToUse );
-        return jvmToUse;
-    }
-
     private String buildClassPathEnvironment() {
         StringBuffer buf = new StringBuffer();
         boolean first = true;

--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -2,31 +2,21 @@ package org.scalatest.tools.maven;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.cli.CommandLineException;
-import org.codehaus.plexus.util.cli.CommandLineTimeOutException;
-import org.codehaus.plexus.util.cli.CommandLineUtils;
-import org.codehaus.plexus.util.cli.Commandline;
-import org.codehaus.plexus.util.cli.StreamConsumer;
+import org.codehaus.plexus.util.cli.*;
 
-import static org.scalatest.tools.maven.MojoUtils.*;
-
-import java.io.*;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-
-import static java.util.Collections.singletonList;
-
-import java.net.MalformedURLException;
-import java.net.URLClassLoader;
-import java.net.URL;
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.scalatest.tools.maven.MojoUtils.*;
 
 /**
  * Provides the base for all mojos.
@@ -270,7 +260,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
 
         final Commandline cli = new Commandline();
         cli.setWorkingDirectory(project.getBasedir());
-        cli.setExecutable("java");
+        cli.setExecutable(getJvm());
 
         // Set up environment
         if (environmentVariables != null) {
@@ -327,6 +317,19 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
         catch (final CommandLineException e) {
             throw new MojoFailureException("Exception while executing forked process.", e);
         }
+    }
+
+    private String getJvm()
+    {
+        // use the same JVM as the one used to run Maven (the "java.home" one)
+        String jvmToUse = System.getProperty( "java.home" ) + File.separator + "bin" + File.separator + "java";
+
+        if (isEmpty(jvmToUse)) {
+            jvmToUse = "java";
+        }
+
+        getLog().debug( "Using JVM: " + jvmToUse );
+        return jvmToUse;
     }
 
     private String buildClassPathEnvironment() {

--- a/src/main/java/org/scalatest/tools/maven/MojoUtils.java
+++ b/src/main/java/org/scalatest/tools/maven/MojoUtils.java
@@ -3,7 +3,8 @@ package org.scalatest.tools.maven;
 import java.util.List;
 import java.util.ArrayList;
 import java.io.File;
-import java.io.IOException;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Provides internal utilities for the Mojo's operations.
@@ -120,5 +121,13 @@ final class MojoUtils {
             c.addAll(l);
         }
         return c.toArray(new String[c.size()]);
+    }
+
+    static String getJvm() {
+        if (!isEmpty(System.getProperty( "java.home" ))) {
+            return System.getProperty( "java.home" ) + File.separator + "bin" + File.separator + "java";
+        } else {
+            return "java";
+        }
     }
 }

--- a/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
@@ -1,6 +1,6 @@
 package org.scalatest.tools.maven
 
-import org.junit.{Before, Test}
+import org.junit.{After, Before, Test}
 
 class MojoUtilsTest {
   private var savedJavaHome: Option[String] = _
@@ -10,6 +10,7 @@ class MojoUtilsTest {
     savedJavaHome = Option(System.getProperty("java.home"))
   }
 
+  @After
   def restore() = {
     savedJavaHome match {
       case None => System.clearProperty("java.home")

--- a/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
@@ -1,0 +1,31 @@
+package org.scalatest.tools.maven
+
+import org.junit.{Before, Test}
+
+class MojoUtilsTest {
+  private var savedJavaHome: Option[String] = _
+
+  @Before
+  def save() = {
+    savedJavaHome = Option(System.getProperty("java.home"))
+  }
+
+  def restore() = {
+    savedJavaHome match {
+      case None => System.clearProperty("java.home")
+      case Some(value) => System.setProperty("java.home", value)
+    }
+  }
+
+  @Test
+  def getJvmHappyPath() = {
+    System.setProperty("java.home", "/test/jvm")
+    assert(MojoUtils.getJvm == "/test/jvm/bin/java")
+  }
+
+  @Test
+  def getJvmWithoutJavaHome() = {
+    System.clearProperty("java.home")
+    assert(MojoUtils.getJvm == "java")
+  }
+}

--- a/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
@@ -6,12 +6,12 @@ class MojoUtilsTest {
   private var savedJavaHome: Option[String] = _
 
   @Before
-  def save() = {
+  def save(): Unit = {
     savedJavaHome = Option(System.getProperty("java.home"))
   }
 
   @After
-  def restore() = {
+  def restore(): Unit = {
     savedJavaHome match {
       case None => System.clearProperty("java.home")
       case Some(value) => System.setProperty("java.home", value)
@@ -19,13 +19,13 @@ class MojoUtilsTest {
   }
 
   @Test
-  def getJvmHappyPath() = {
+  def getJvmHappyPath(): Unit = {
     System.setProperty("java.home", "/test/jvm")
     assert(MojoUtils.getJvm == "/test/jvm/bin/java")
   }
 
   @Test
-  def getJvmWithoutJavaHome() = {
+  def getJvmWithoutJavaHome(): Unit = {
     System.clearProperty("java.home")
     assert(MojoUtils.getJvm == "java")
   }


### PR DESCRIPTION
Use the java executable that Maven ran with.  Inspired from the Surefire plugin's [getEffectiveJvm](https://github.com/apache/maven-surefire/blob/surefire-2.22.2/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java#L2283-L2336) minus the toolchain lookup.

Fixes #6, #14 and #26 