### PR TITLE
Add verify stage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>org.scalatest</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.0.0</version>
+  <version>3.0.0</version>
   <name>ScalaTest Maven Plugin</name>
   <description>Integrates ScalaTest into Maven</description>
 

--- a/src/main/java/org/scalatest/tools/maven/VerifyMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/VerifyMojo.java
@@ -1,0 +1,50 @@
+package org.scalatest.tools.maven;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ * A verification that all the tests passed.
+ * @phase verify
+ * @goal verify
+ */
+public class VerifyMojo extends AbstractScalaTestMojo {
+
+  /**
+   * The summary file to read integration test results from.
+   * @parameter default-value="${project.build.directory}/surefire-reports/scalatest-summary.txt" property="scalatest.reportsDirectory"
+   */
+  private File summaryFile;
+
+  public void execute() throws MojoExecutionException {
+      try {
+        File reportFile = new File(summaryFile.getAbsolutePath());
+        // FileReader reads text files in the default encoding.
+        FileReader fileReader =
+            new FileReader(reportFile);
+
+        // Always wrap FileReader in BufferedReader.
+        BufferedReader bufferedReader =
+            new BufferedReader(fileReader);
+        if(bufferedReader.readLine().contentEquals("failure")) {
+          bufferedReader.close();
+          throw new MojoExecutionException("There are test failures");
+        } else {
+          bufferedReader.close();
+          throw new MojoExecutionException("File has invalid content");
+        }
+      }
+      catch(FileNotFoundException ex) {
+        throw new MojoExecutionException("Cannot find file: "+summaryFile.getAbsolutePath());
+      }
+      catch(IOException ex) {
+        throw new MojoExecutionException("IOException: "+ ex.toString());
+      }
+    //}
+  }
+}

--- a/src/site/apt/usage.apt
+++ b/src/site/apt/usage.apt
@@ -115,6 +115,7 @@ Usage Documentation
       <execution>
         <goals>
           <goal>test</goal>
+          <goal>verify</goal>
         </goals>
         <configuration>
           <xmlreports>test-results</xmlreports>
@@ -138,6 +139,7 @@ Usage Documentation
             <execution>
               <goals>
                 <goal>test</goal>
+                <goal>verify</goal>
               </goals>
               <configuration>
                 <xmlreports>test-results</xmlreports>
@@ -150,6 +152,42 @@ Usage Documentation
     </build>
   </profile>
 </profiles>
++--
+
+* Allowing the Post-Integration Phase to run
+
+  In its original implementation, the plugin fails the build immediately if there is a test failure.
+  If you are using a dockerized test setup, this is bad behavior because your docker instances will
+  not have enough time to shutdown (https://github.com/scalatest/scalatest-maven-plugin/issues/45).
+  You can use these config values to stop this from happening by failing the build in the verification
+  stage rather than the testing phase.
+
++--
+
+<plugin>
+  <groupId>org.scalatest</groupId>
+  <artifactId>scalatest-maven-plugin</artifactId>
+  <version>3.0.0</version>
+  <configuration>
+    <runVerifyOnFailure>true</runVerifyOnFailure>
+  </configuration>
+  <executions>
+    <execution>
+      <id>test</id>
+      <phase>integration-test</phase>
+      <goals>
+        <goal>test</goal>
+      </goals>
+    </execution>
+    <execution>
+      <id>verify</id>
+      <goals>
+        <goal>verify</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+
 +--
 
   The "test" and "gui" goals support multiple Reporters of different types and formatting options for each


### PR DESCRIPTION
This Pull Request is an extension of https://github.com/scalatest/scalatest-maven-plugin/issues/59, adding a verify stage would help people who use docker to be able to use the scalatest-maven-plugin because it allows the post-integration test to run. 

This is just a rough outline of what I think could be done. Obviously the file writing system is very crude but it was just my first draft. The Surefire plugin features a `FailsafeSummaryXmlUtils` [class](https://github.com/apache/maven-surefire/blob/master/maven-failsafe-plugin/src/main/java/org/apache/maven/plugin/failsafe/util/FailsafeSummaryXmlUtils.java) that provides utilities for file writing and reading that would provide a good solution to this problem. 