### PR TITLE
Fix plugin name in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ target/
 
 # Editor files
 .dir-locals.el
+
+# IDE files
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ To use the ScalaTest Maven plugin, you need to disable SureFire and enable Scala
     <!-- enable scalatest -- >
     <plugin>
       <groupId>org.scalatest</groupId>
-      <artifactId>maven-scalatest-plugin</artifactId>
-      <version>1.0.M2</version>
+      <artifactId>scalatest-maven-plugin</artifactId>
+      <version>2.0.0</version>
       <configuration>
         <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
         <junitxml>.</junitxml>

--- a/notes.txt
+++ b/notes.txt
@@ -11,7 +11,7 @@ Work done so far
 To Use
 ------
 1. Disable maven-surefire-plugin by setting skipTests=true
-2. Add maven-scalatest-plugin to <build> section and configure the "test" goal in an execution
+2. Add scalatest-maven-plugin to <build> section and configure the "test" goal in an execution
 3. Execute "test" phase or directly execute the scalatest:test or scalatest:gui goals
 
 

--- a/src/site/apt/usage.apt
+++ b/src/site/apt/usage.apt
@@ -4,11 +4,11 @@ Usage Documentation
 
   [[1]] Disable the maven-surefire-plugin
 
-  [[2]] Configure this maven-scalatest-plugin to run in the test phase
+  [[2]] Configure this scalatest-maven-plugin to run in the test phase
 
   []
 
-  To replace the maven-surefire-report-plugin with this plugin, simply add the maven-scalatest-plugin instead of
+  To replace the maven-surefire-report-plugin with this plugin, simply add the scalatest-maven-plugin instead of
   the maven-surefire-report-plugin to the reporting section of the POM.
 
   For example, in the build section of the POM, add something like the following:
@@ -29,7 +29,7 @@ Usage Documentation
   <!-- Enable Scalatest -->
   <plugin>
     <groupId>org.scalatest</groupId>
-    <artifactId>maven-scalatest-plugin</artifactId>
+    <artifactId>scalatest-maven-plugin</artifactId>
     <executions>
       <execution>
         <goals>
@@ -50,7 +50,7 @@ Usage Documentation
   on the maven-surefire-plugin.  There is nothing inherently wrong in having Surefire run your
   tests, but if you want all your tests to run through ScalaTest instead, then disabling Surefire
   in this manner will keep your tests from running twice.  Since the "test" goal of the
-  maven-scalatest-plugin is tied to the test phase by default you do not need to do this explicitly
+  scalatest-maven-plugin is tied to the test phase by default you do not need to do this explicitly
   in your POM.
 
   Optionally, in the reporting section of the POM you can add something like the following:
@@ -61,7 +61,7 @@ Usage Documentation
 
   <plugin>
     <groupId>org.scalatest</groupId>
-    <artifactId>maven-scalatest-plugin</artifactId>
+    <artifactId>scalatest-maven-plugin</artifactId>
     <configuration>
       <fileReporterOptions>...</fileReporterOptions>
     </configuration>
@@ -110,7 +110,7 @@ Usage Documentation
   ...
   <plugin>
     <groupId>org.scalatest</groupId>
-    <artifactId>maven-scalatest-plugin</artifactId>
+    <artifactId>scalatest-maven-plugin</artifactId>
     <executions>
       <execution>
         <goals>
@@ -133,7 +133,7 @@ Usage Documentation
       <plugins>
         <plugin>
           <groupId>org.scalatest</groupId>
-          <artifactId>maven-scalatest-plugin</artifactId>
+          <artifactId>scalatest-maven-plugin</artifactId>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
This pull request only touches documentation (and `.gitignore`). The integration test in `src/it/manual/gui/pom.xml` also refers to the old name `maven-scalatest-plugin`, but I couldn't get it to run, so I left it alone. 