### PR TITLE
Fixes #57 using un-modifyable lists & judicious synchronization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>org.scalatest</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>ScalaTest Maven Plugin</name>
   <description>Integrates ScalaTest into Maven</description>
 

--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -11,6 +11,7 @@ import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.codehaus.plexus.util.cli.StreamConsumer;
 
+import static java.util.Collections.unmodifiableList;
 import static org.scalatest.tools.maven.MojoUtils.*;
 
 import java.io.*;
@@ -398,7 +399,8 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
 
     // This is the configuration parameters shared by all concrete Mojo subclasses
     List<String> sharedConfiguration() {
-        return new ArrayList<String>() {{
+        return unmodifiableList(
+            new ArrayList<String>() {{
             addAll(runpath());
             addAll(config());
             addAll(tagsToInclude());
@@ -414,7 +416,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
             addAll(testsFiles());
             addAll(junitClasses());
             addAll(spanScaleFactor());
-        }};
+        }});
     }
 
     private List<String> config() {
@@ -422,7 +424,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
         for(String pair : splitOnComma(config)){
             c.add("-D"+pair);
         }
-        return c;
+        return unmodifiableList(c);
     }
 
     private List<String> runpath() {
@@ -441,7 +443,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
     }
 
     private List<String> parallel() {
-        return parallel ? singletonList("-P") : Collections.<String>emptyList();
+        return parallel ? unmodifiableList(singletonList("-P")) : Collections.<String>emptyList();
     }
 
     //
@@ -469,7 +471,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
                 }
             }
         }
-        return list;
+        return unmodifiableList(list);
     }
 
     //
@@ -536,7 +538,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
         for (String test: splitOnComma(tests)) {
             addTest(list, test);
         }
-        return list;
+        return unmodifiableList(list);
     }
 
     private List<String> spanScaleFactor() {
@@ -545,7 +547,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
             list.add("-F");
             list.add(spanScaleFactor + "");
         }
-        return list;
+        return unmodifiableList(list);
     }
 
     private List<String> suffixes() {
@@ -577,7 +579,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
                 list.add(param);
             }
         }
-        return list;
+        return unmodifiableList(list);
     }
 
     private List<String> junitClasses() {

--- a/src/main/java/org/scalatest/tools/maven/MojoUtils.java
+++ b/src/main/java/org/scalatest/tools/maven/MojoUtils.java
@@ -1,9 +1,12 @@
 package org.scalatest.tools.maven;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.io.File;
 import java.io.IOException;
+
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Provides internal utilities for the Mojo's operations.
@@ -46,7 +49,7 @@ final class MojoUtils {
     }
 
     // sideeffect!
-    private static void createIfNotExists(File dir) {
+    private static synchronized void createIfNotExists(File dir) {
         if(!dir.exists() && !dir.mkdirs()){
             throw new IllegalStateException("Cannot create directory " + dir);
         }
@@ -69,7 +72,7 @@ final class MojoUtils {
             }
             list.add(a);
         }
-        return list;
+        return unmodifiableList(list);
     }
 
     static List<String> suiteArg(String name, String commaSeparated) {
@@ -78,7 +81,7 @@ final class MojoUtils {
             list.add(name);
             list.add(param);
         }
-        return list;
+        return unmodifiableList(list);
     }
 
     static List<String> reporterArg(String name, String commaSeparated, F map) {
@@ -93,7 +96,7 @@ final class MojoUtils {
                 r.add(map.f(split[1]));
             }
         }
-        return r;
+        return unmodifiableList(r);
     }
 
     //
@@ -104,13 +107,13 @@ final class MojoUtils {
     static List<String> splitOnComma(String cs) {
         List<String> args = new ArrayList<String>();
         if (cs == null) {
-            return args;
+            return unmodifiableList(args);
         } else {
             String[] split = cs.split("(?<!\\\\),");
             for (String arg : split) {
                 args.add(arg.trim().replaceAll("\\\\,", ","));
             }
-            return args;
+            return unmodifiableList(args);
         }
     }
 

--- a/src/main/java/org/scalatest/tools/maven/TestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/TestMojo.java
@@ -7,6 +7,7 @@ import static org.scalatest.tools.maven.MojoUtils.*;
 import java.io.File;
 import java.util.Collections;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -21,6 +22,7 @@ import java.util.ArrayList;
  * @author Bill Venners
  * @phase test
  * @goal test
+ * @threadSafe
  */
 public class TestMojo extends AbstractScalaTestMojo {
 
@@ -124,15 +126,15 @@ public class TestMojo extends AbstractScalaTestMojo {
     // These private methods create the relevant portion of the command line
     // to pass to Runner based on the corresponding Maven configuration parameter.
     private List<String> stdout() {
-        return singletonList(stdout == null ? "-o" : "-o" + stdout);
+        return unmodifiableList(singletonList(stdout == null ? "-o" : "-o" + stdout));
     }
 
     private List<String> stderr() {
-        return stderr == null ? Collections.<String>emptyList() : singletonList("-e" + stderr);
+        return stderr == null ? Collections.<String>emptyList() : unmodifiableList(singletonList("-e" + stderr));
     }
 
     private List<String> filereports() {
-        return reporterArg("-f", filereports, fileRelativeTo(reportsDirectory));
+        return unmodifiableList(reporterArg("-f", filereports, fileRelativeTo(reportsDirectory)));
     }
 
     private List<String> htmlreporters() {
@@ -151,7 +153,7 @@ public class TestMojo extends AbstractScalaTestMojo {
                 }
             }
         }
-        return r;
+        return unmodifiableList(r);
     }
 
     private List<String> reporters() {


### PR DESCRIPTION
Mostly just ensuring lists are un-modifyable. Added synchronization to the side-effect code which creates a directory if it doesn't exist. Not sure how to test this, but in the build that inspired this change, the warnings are gone, and all is well.