### PR TITLE
Strip new lines in argLine and debugArgLine parameters

### DIFF
--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -6,21 +6,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.cli.*;
 
-import static java.util.Collections.unmodifiableList;
-import static org.scalatest.tools.maven.MojoUtils.*;
-
-import java.io.*;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-
-import static java.util.Collections.singletonList;
-
-import java.net.MalformedURLException;
-import java.net.URLClassLoader;
-import java.net.URL;
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -29,7 +15,7 @@ import java.net.URLClassLoader;
 import java.util.*;
 
 import static java.util.Collections.singletonList;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static java.util.Collections.unmodifiableList;
 import static org.scalatest.tools.maven.MojoUtils.*;
 
 /**
@@ -294,12 +280,12 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
 
         // Set user specified JVM arguments
         if (argLine != null) {
-            cli.createArg().setLine(argLine);
+            cli.createArg().setLine(stripNewLines(argLine));
         }
 
         // Set debugging JVM arguments if debugging is enabled
         if (debugForkedProcess) {
-            cli.createArg().setLine(forkedProcessDebuggingArguments());
+            cli.createArg().setLine(stripNewLines(forkedProcessDebuggingArguments()));
         }
 
         // Set ScalaTest arguments

--- a/src/main/java/org/scalatest/tools/maven/MojoUtils.java
+++ b/src/main/java/org/scalatest/tools/maven/MojoUtils.java
@@ -147,4 +147,8 @@ final class MojoUtils {
         }
         return result;
     }
+
+    static String stripNewLines(String argLine) {
+        return argLine.replaceAll("[\r\n]{1,2}", " ");
+    }
 }

--- a/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
@@ -208,4 +208,14 @@ final class PluginTest
     MojoUtils.compoundArg("-a", comma("a", "b", "c")) should be(jlist("-a", "a b c"))
     MojoUtils.compoundArg("-a", null.asInstanceOf[String]) should be(jlist())
   }
+
+  def testMojoStripNewLines {
+    MojoUtils.stripNewLines("-XmsXg -XmxYg -XX:MaxPermSize=Zm") should be("-XmsXg -XmxYg -XX:MaxPermSize=Zm")
+    MojoUtils.stripNewLines("-XmsXg\n-XmxYg -XX:MaxPermSize=Zm") should be("-XmsXg -XmxYg -XX:MaxPermSize=Zm")
+    MojoUtils.stripNewLines("-XmsXg\n-XmxYg") should be("-XmsXg -XmxYg")
+    MojoUtils.stripNewLines("-XmsXg\r-XmxYg -XX:MaxPermSize=Zm") should be("-XmsXg -XmxYg -XX:MaxPermSize=Zm")
+    MojoUtils.stripNewLines("-XmsXg\r-XmxYg") should be("-XmsXg -XmxYg")
+    MojoUtils.stripNewLines("-XmsXg\r\n-XmxYg -XX:MaxPermSize=Zm") should be("-XmsXg -XmxYg -XX:MaxPermSize=Zm")
+    MojoUtils.stripNewLines("-XmsXg\r\n-XmxYg") should be("-XmsXg -XmxYg")
+  }
 }


### PR DESCRIPTION
# Problem
Formatters sometime causes new lines in `pom.xml` files:

```
        <argLine>-Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g
          -Dlog4j2.configurationFile=log4j2-fatal-only.xml
        </argLine>
```

This result in failures at java command execution:

```
[INFO] --- scalatest-maven-plugin:1.0:test (test) @ test-project ---
Usage: java [-options] class [args...]
           (to execute a class)
   or  java [-options] -jar jarfile [args...]
           (to execute a jar file)
where options include:
    -d32	  use a 32-bit data model if available
    -d64	  use a 64-bit data model if available
    -server	  to select the "server" VM
                  The default VM is server,
                  because you are running on a server-class machine.


    -cp <class search path of directories and zip/jar files>
    -classpath <class search path of directories and zip/jar files>
                  A : separated list of directories, JAR archives,
                  and ZIP archives to search for class files.
    -D<name>=<value>
                  set a system property
    -verbose:[class|gc|jni]
                  enable verbose output
    -version      print product version and exit
    -version:<value>
                  Warning: this feature is deprecated and will be removed
                  in a future release.
                  require the specified version to run
    -showversion  print product version and continue
    -jre-restrict-search | -no-jre-restrict-search
                  Warning: this feature is deprecated and will be removed
                  in a future release.
                  include/exclude user private JREs in the version search
    -? -help      print this help message
    -X            print help on non-standard options
    -ea[:<packagename>...|:<classname>]
    -enableassertions[:<packagename>...|:<classname>]
                  enable assertions with specified granularity
    -da[:<packagename>...|:<classname>]
    -disableassertions[:<packagename>...|:<classname>]
                  disable assertions with specified granularity
    -esa | -enablesystemassertions
                  enable system assertions
    -dsa | -disablesystemassertions
                  disable system assertions
    -agentlib:<libname>[=<options>]
                  load native agent library <libname>, e.g. -agentlib:hprof
                  see also, -agentlib:jdwp=help and -agentlib:hprof=help
    -agentpath:<pathname>[=<options>]
                  load native agent library by full pathname
    -javaagent:<jarpath>[=<options>]
                  load Java programming language agent, see java.lang.instrument
    -splash:<imagepath>
                  show splash screen with specified image
See http://www.oracle.com/technetwork/java/javase/documentation/index.html for more details.
/bin/sh: line 1: -Dlog4j2.configurationFile=log4j2-fatal-only.xml: command not found
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  20.805 s
[INFO] Finished at: 2020-08-09T02:39:43+03:00
```

# Solution

This PR replaces platform-agnostic new line delimiters ("\r", "\n", "\r\n") in argLine & debugArgLine with ordinary spaces (" ") to allow multiline JVM argument lists.

# Reference

`maven-surefire-plugin` also have a fix for this:

https://github.com/apache/maven-surefire/blob/eb48f1b59ca5ccf6954ef33ecab03dbaf93214cd/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/booterclient/DefaultForkConfiguration.java#L246-L249