### PR TITLE
Add support for maven.test.redirectTestOutputToFile

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,20 @@
+name: scalatest-maven-plugin
+
+on: [push]
+
+jobs:
+  verify:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: git
+        uses: actions/checkout@v2
+
+      - name: java
+        uses: actions/setup-java@v1.4.2
+        with:
+          java-version: '8'
+
+      - name: maven
+        run: mvn -B clean verify --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -19,10 +21,13 @@
     <scala.major.version>2.11</scala.major.version>
     <scala.minor.version>12</scala.minor.version>
     <scala.version>${scala.major.version}.${scala.minor.version}</scala.version>
+
     <scalatest.version>3.0.1</scalatest.version>
     <scala.maven.plugin.version>4.3.0</scala.maven.plugin.version>
+
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
@@ -32,7 +37,8 @@
     <junit.version>4.12</junit.version>
     <maven.reporting.api.version>3.0</maven.reporting.api.version>
     <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
-    <java.version>6</java.version>
+
+    <java.version>8</java.version>
   </properties>
 
   <licenses>
@@ -129,16 +135,6 @@
     </pluginManagement>
 
     <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
@@ -161,8 +157,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.${java.version}</source>
-          <target>1.${java.version}</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
         </configuration>
       </plugin>
       <plugin>
@@ -194,6 +190,7 @@
           <pomIncludes>
             <pomInclude>lift/pom.xml</pomInclude>
             <pomInclude>spaces in path/pom.xml</pomInclude>
+            <pomInclude>redirect-output/pom.xml</pomInclude>
           </pomIncludes>
           <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
           <streamLogs>true</streamLogs>
@@ -205,21 +202,6 @@
             <goal>site</goal>
           </goals>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>${maven.gpg.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -245,58 +227,89 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <version>2.6</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.5.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-changes-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <filteringChanges>true</filteringChanges>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.3</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <charset>UTF-8</charset>
-          <docencoding>UTF-8</docencoding>
-          <docfilessubdirs>true</docfilessubdirs>
-          <show>package</show>
-          <source>1.${java.version}</source>
-          <detectLinks>true</detectLinks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.2</version>
-        <configuration>
-          <inputEncoding>UTF-8</inputEncoding>
-          <outputEncoding>UTF-8</outputEncoding>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-    </plugins>
-  </reporting>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.7</version>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven.gpg.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <reporting>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-plugin-plugin</artifactId>
+            <version>2.6</version>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>cobertura-maven-plugin</artifactId>
+            <version>2.5.1</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-changes-plugin</artifactId>
+            <version>2.6</version>
+            <configuration>
+              <filteringChanges>true</filteringChanges>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.3</version>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.7</version>
+            <configuration>
+              <charset>UTF-8</charset>
+              <docencoding>UTF-8</docencoding>
+              <docfilessubdirs>true</docfilessubdirs>
+              <show>package</show>
+              <source>${java.version}</source>
+              <detectLinks>true</detectLinks>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jxr-plugin</artifactId>
+            <version>2.2</version>
+            <configuration>
+              <inputEncoding>UTF-8</inputEncoding>
+              <outputEncoding>UTF-8</outputEncoding>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-report-plugin</artifactId>
+            <version>2.5</version>
+          </plugin>
+        </plugins>
+      </reporting>
+    </profile>
+  </profiles>
 </project>

--- a/src/it/redirect-output/README.md
+++ b/src/it/redirect-output/README.md
@@ -1,0 +1,3 @@
+# redirect output
+
+This project is part of scalatest-maven-plugin's suite of integration tests.  It is meant to check that scalatest-maven-plugin can run for projects that use test output redirect.

--- a/src/it/redirect-output/invoker.properties
+++ b/src/it/redirect-output/invoker.properties
@@ -1,0 +1,3 @@
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean test

--- a/src/it/redirect-output/pom.xml
+++ b/src/it/redirect-output/pom.xml
@@ -1,0 +1,96 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>redirect-output-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>redirect-output</name>
+  <description>Runs the plugin for a project that uses test output redirect.</description>
+
+  <parent>
+    <groupId>maven.scalatest.plugin.its</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>@scala.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_@scala.major.version@</artifactId>
+      <version>@scalatest.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>@scala.maven.plugin.version@</version>
+        <configuration>
+          <recompileMode>incremental</recompileMode>
+          <scalaVersion>${scala.version}</scalaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scala-compile</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>add-source</goal>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- disable surefire -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <!-- enable scalatest -->
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <logForkedProcessCommand>true</logForkedProcessCommand>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/redirect-output/src/main/scala/org/example/App.scala
+++ b/src/it/redirect-output/src/main/scala/org/example/App.scala
@@ -1,0 +1,7 @@
+package org.example
+
+class App {
+  def runApp(): String = {
+    "It ran!"
+  }
+}

--- a/src/it/redirect-output/src/test/scala/org/example/AppTest.scala
+++ b/src/it/redirect-output/src/test/scala/org/example/AppTest.scala
@@ -1,0 +1,10 @@
+package org.example
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class AppTest extends FlatSpec with Matchers {
+  "Our example App" should "run" in {
+    val app = new App
+    app.runApp() shouldBe "It ran!"
+  }
+}

--- a/src/it/redirect-output/verify.groovy
+++ b/src/it/redirect-output/verify.groovy
@@ -1,8 +1,9 @@
 
-def logsFile = new File(basedir, "build.log")
+def reportsDir = new File(basedir, "target" + File.separator + "scalatest-reports")
+def logsFile = new File(reportsDir,  "scalatest-output.txt")
 
 if (!logsFile.exists()) {
-  throw new Exception("Could not find build.log.  Searched: " + logsFile)
+  throw new Exception("Could not find output.txt.  Searched: " + logsFile)
 }
 
 def testSummaryLines = []
@@ -12,15 +13,15 @@ logsFile.filterLine {
 }.each { line -> testSummaryLines << "" + line }
 
 if (testSummaryLines.size == 0) {
-  throw new Exception("Could not find scalatest's summary line in build.log")
+  throw new Exception("Could not find scalatest's summary line in output.txt")
 } else if (testSummaryLines.size > 1) {
-  throw new Exception("Found more than one scalatest summary line in build.log")
+  throw new Exception("Found more than one scalatest summary line in output.txt")
 }
 
 def theLine = testSummaryLines[0]
 
 if (theLine.isEmpty()) {
-  throw new Exception("Could not find scalatest's non empty summary line in build.log")
+  throw new Exception("Could not find scalatest's non-empty summary line in output.txt")
 }
 
 if (theLine.contains("Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0")) {

--- a/src/it/spaces in path/verify.groovy
+++ b/src/it/spaces in path/verify.groovy
@@ -17,7 +17,13 @@ if (testSummaryLines.size == 0) {
   throw new Exception("Found more than one scalatest summary line in build.log")
 }
 
-if (testSummaryLines[0].contains("Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0")) {
+def theLine = testSummaryLines[0]
+
+if (theLine.isEmpty()) {
+  throw new Exception("Could not find scalatest's non empty summary line in build.log")
+}
+
+if (theLine.contains("Tests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0")) {
   throw new Exception("No tests were run by scalatest!")
 }
 

--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -7,6 +7,9 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.cli.*;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -220,7 +223,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
     /**
      * Span scale factor.
      *
-     * @parameter expression="${spanScaleFactor}"
+     * @parameter property="spanScaleFactor" default-value="1.0"
      */
     double spanScaleFactor = 1.0;
 
@@ -302,21 +305,34 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
             getLog().debug(commandLogStatement);
         }
 
-        final StreamConsumer streamConsumer = new StreamConsumer() {
-            public void consumeLine(final String line) {
-                System.out.println(line);
-            }
-        };
-        try {
-            final int result = CommandLineUtils.executeCommandLine(cli, streamConsumer, streamConsumer, forkedProcessTimeoutInSeconds);
+        try (
+            final Writer outputWriter = getOutputWriter()
+        ) {
+            final StreamConsumer outputConsumer = new WriterStreamConsumer(outputWriter);
+
+            final int result = CommandLineUtils.executeCommandLine(cli, outputConsumer, outputConsumer,
+                    forkedProcessTimeoutInSeconds);
+
             return result == 0;
         }
         catch (final CommandLineTimeOutException e) {
-            throw new MojoFailureException(String.format("Timed out after %d seconds waiting for forked process to complete.", forkedProcessTimeoutInSeconds));
+            throw new MojoFailureException(String.format("Timed out after %d seconds waiting for forked process to complete.", forkedProcessTimeoutInSeconds), e);
         }
         catch (final CommandLineException e) {
             throw new MojoFailureException("Exception while executing forked process.", e);
         }
+        catch (IOException e) {
+            throw new MojoFailureException("Unable to close the output writer ", e);
+        }
+    }
+
+    protected Writer getOutputWriter() throws MojoFailureException {
+        return new PrintWriter(System.out) {
+            @Override
+            public void close() {
+                out = null; // System.out should stay open
+            }
+        };
     }
 
     private String buildClassPathEnvironment() {

--- a/src/main/java/org/scalatest/tools/maven/TestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/TestMojo.java
@@ -1,15 +1,18 @@
 package org.scalatest.tools.maven;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import static org.scalatest.tools.maven.MojoUtils.*;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
-import java.util.List;
-import java.util.ArrayList;
+import static org.scalatest.tools.maven.MojoUtils.*;
 
 /**
  * Provides a bridge between Maven and the command-line form of ScalaTest's Runner.
@@ -101,7 +104,26 @@ public class TestMojo extends AbstractScalaTestMojo {
      */
     String stderr;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    /**
+     * Set this to "true" to redirect the unit test standard output to a file
+     * (found in reportsDirectory/scalatest-output.txt by default).
+     * <p>
+     * NOTE: Works only if forkMode="once"
+     *
+     * @parameter property="maven.test.redirectTestOutputToFile" default-value="false"
+     */
+    boolean redirectTestOutputToFile;
+
+    /**
+     * Name of the file where the test output is redirected if enabled
+     *
+     * @parameter default-value="scalatest-output.txt"
+     */
+    String testOutputFileName;
+
+    public void execute() throws MojoFailureException {
+        getLog().info("ScalaTest report directory: " + reportsDirectory);
+
         if (skipTests) {
             getLog().info("Tests are skipped.");
         } else {
@@ -126,11 +148,30 @@ public class TestMojo extends AbstractScalaTestMojo {
     // These private methods create the relevant portion of the command line
     // to pass to Runner based on the corresponding Maven configuration parameter.
     private List<String> stdout() {
-        return unmodifiableList(singletonList(stdout == null ? "-o" : "-o" + stdout));
+        final String stdoutProcessed = maybeRemoveAnsiCodes(stdout);
+        return unmodifiableList(singletonList(stdoutProcessed == null ? "-o" : "-o" + stdoutProcessed));
     }
 
     private List<String> stderr() {
         return stderr == null ? Collections.<String>emptyList() : unmodifiableList(singletonList("-e" + stderr));
+    }
+
+    private String maybeRemoveAnsiCodes(String streamParams) {
+        return redirectTestOutputToFile
+                ? maybeAppendLetter(streamParams, "W")
+                : streamParams;
+    }
+
+    private String maybeAppendLetter(String string, String letter) {
+        if (string == null) {
+            return letter;
+        }
+
+        if (string.contains(letter)) {
+            return string;
+        }
+
+        return string + letter;
     }
 
     private List<String> filereports() {
@@ -162,5 +203,23 @@ public class TestMojo extends AbstractScalaTestMojo {
 
     private List<String> junitxml(){
         return reporterArg("-u", junitxml, dirRelativeTo(reportsDirectory));
+    }
+
+    protected Writer getOutputWriter() throws MojoFailureException {
+        return redirectTestOutputToFile ? newFileWriter() : super.getOutputWriter();
+    }
+
+    private Writer newFileWriter() throws MojoFailureException {
+        final File outputFile = new File(reportsDirectory, testOutputFileName);
+
+        if (!reportsDirectory.exists() && !reportsDirectory.mkdirs()) {
+            throw new MojoFailureException("Unable to create directory path: " + reportsDirectory);
+        }
+
+        try {
+            return new FileWriter(outputFile);
+        } catch (IOException e) {
+            throw new MojoFailureException("Unable to access the output file: '" + outputFile + "'", e);
+        }
     }
 }

--- a/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
@@ -102,6 +102,10 @@ final class PluginTest
     configure(_.stdout = "GUP") should contain("-oGUP")
   }
 
+  def testStdOutReporterWithRedirect {
+    configure(_.redirectTestOutputToFile = true) should contain("-oW")
+  }
+
   def testStdErrReporter {
     configure(_.stderr = "BIS") should contain("-eBIS")
   }


### PR DESCRIPTION
Hi

This change will make the build logs shorter for cases when the tests produce lots of logs.
Please review.

Details:
 - disable ANSI codes if enabled
 - allow customization of the output file name
 - fix IT verify scripts to catch empty line case
 - upgrade java version to 8 (build was failing)
 - IT which verifies output is redirected
 - move release related pom configuration to a dedicated profile
 - fixed warnings related to javadoc annotations (spanScaleFactor)
 - run maven verify on push

Regards
Greg