### PR TITLE
Give priority to "java.home" property over "JAVA_HOME" environment variable.        

### DIFF
--- a/src/main/java/org/scalatest/tools/maven/MojoUtils.java
+++ b/src/main/java/org/scalatest/tools/maven/MojoUtils.java
@@ -127,10 +127,11 @@ final class MojoUtils {
 
     private static String getJavaHome() {
         final String result;
-        if (!isEmpty(System.getenv("JAVA_HOME"))) {
-            result = System.getenv("JAVA_HOME");
-        } else if (!isEmpty(System.getProperty("java.home"))) {
+        if (!isEmpty(System.getProperty("java.home"))) {
             result = System.getProperty("java.home");
+        }
+        else if (!isEmpty(System.getenv("JAVA_HOME"))) {
+            result = System.getenv("JAVA_HOME");
         } else {
             result = null;
         }

--- a/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/MojoUtilsTest.scala
@@ -38,6 +38,6 @@ class MojoUtilsTest {
   def getJvmJavaHomeIsPriority(): Unit = {
     System.setProperty("java.home", "/test/jvm")
     env.set("JAVA_HOME", "/opt/jdk-11")
-    assert(MojoUtils.getJvm == "/opt/jdk-11/bin/java")
+    assert(MojoUtils.getJvm == "/test/jvm/bin/java")
   }
 }


### PR DESCRIPTION
Solves #80
