### PR TITLE
Allow to specify JVM path

### DIFF
--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -234,6 +234,14 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
      */
     String workingDirectory;
 
+    /**
+     * Option to specify an alternative path to JVM (or path to the java executable) to use with
+     * the forked process.
+     *
+     * @parameter property="jvm"
+     */
+    String jvm;
+
     // runScalaTest is called by the concrete mojo subclasses  TODO: make it protected and others too
     // Returns true if all tests pass
     boolean runScalaTest(String[] args) throws MojoFailureException {
@@ -274,7 +282,12 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
         } else {
             cli.setWorkingDirectory(workingDirectory);
         }
-        cli.setExecutable(getJvm());
+
+        if (this.jvm == null || this.jvm.isEmpty()) {
+            cli.setExecutable(getJvm());
+        } else {
+            cli.setExecutable(this.jvm);
+        }
 
         // Set up environment
         if (environmentVariables != null) {


### PR DESCRIPTION
This change adds a capability to explicitly specify the path to Java executable for the forked process. This option works similar to Surefire's `<jvm>` configuration field.

We have custom version of Spark which uses JNI. We have a custom wrapper around java executable that starts the actual java processes using ld.so and sets all LD_ environment variables. Unfortunately the existing way of setting a JVM path via JAVA_HOME added in #43 doesn't quite work for us, as well as it's not unified with the Surefire config.