### PR TITLE
Versions Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 
   <properties>
     <scala.major.version>2.12</scala.major.version>
-    <scala.minor.version>16</scala.minor.version>
+    <scala.minor.version>17</scala.minor.version>
     <scala.version>${scala.major.version}.${scala.minor.version}</scala.version>
-    <scalatest.version>3.2.12</scalatest.version>
+    <scalatest.version>3.2.14</scalatest.version>
     <scala.maven.plugin.version>4.3.0</scala.maven.plugin.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/lift/src/test/scala/demo/helloworld/AppTest.scala
+++ b/src/it/lift/src/test/scala/demo/helloworld/AppTest.scala
@@ -43,9 +43,14 @@ class AppTest extends AnyFunSuite {
 
       if (file.isFile && handledXml(file.getName)) {
         try {
-          XML.loadFile(file)
+          val f = javax.xml.parsers.SAXParserFactory.newInstance()
+          f.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+          val p = f.newSAXParser()
+          XML.withSAXParser(p).loadFile(file)
         } catch {
-          case e: _root_.org.xml.sax.SAXParseException => failed = file :: failed
+          case e: _root_.org.xml.sax.SAXParseException => 
+            e.printStackTrace()
+            failed = file :: failed
         }
       }
       if (file.isFile && handledXHtml(file.getName)) {

--- a/src/it/no-scalatest-ignore/pom.xml
+++ b/src/it/no-scalatest-ignore/pom.xml
@@ -12,7 +12,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.8</version>
+      <version>@scala.version@</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
GitHub's dependabot detected that this repo has a security vulnebility due to scala 2.13.8: 

https://github.com/scalatest/scalatest-maven-plugin/security/dependabot

The main of this plugin is written in java and does not depend on Scala, the only one child project that is using scala 2.13.8 is a integration test project, I have changed it to follow parent project's scala version in this PR, also, I have bumped up the scala version to 2.12.17 and scalatest version to 3.2.14.

Thanks.